### PR TITLE
Use same rules for js as for ts

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,41 +1,44 @@
+const rules = {
+  // tslint (https://palantir.github.io/tslint/rules/)
+  "align": false,
+  "arrow-parens": false,
+  "eofline": false,
+  "import-spacing": false,
+  "indent": false,
+  "linebreak-style": false,
+  "max-line-length": false,
+  "new-parens": false,
+  "no-consecutive-blank-lines": false,
+  "no-irregular-whitespace": false,
+  "no-trailing-whitespace": false,
+  "object-literal-key-quotes": false,
+  "one-line": false,
+  "quotemark": false,
+  "semicolon": false,
+  "space-before-function-paren": false,
+  "trailing-comma": false,
+  "whitespace": false,
+
+  // tslint-react (https://github.com/palantir/tslint-react)
+  "jsx-alignment": false,
+  "jsx-curly-spacing": false,
+  "jsx-no-multiline-js": false,
+  "jsx-wrap-multiline": false,
+
+  // tslint-eslint-rules (https://github.com/buzinas/tslint-eslint-rules)
+  "block-spacing": false,
+  "brace-style": false,
+  "no-multi-spaces": false,
+  "object-curly-spacing": false,
+  "space-in-parens": false,
+  "ter-arrow-parens": false,
+  "ter-arrow-spacing": false,
+  "ter-indent": false,
+  "ter-max-len": false,
+  "ter-no-irregular-whitespace": false
+};
+
 module.exports = {
-  rules: {
-    // tslint (https://palantir.github.io/tslint/rules/)
-    "align": false,
-    "arrow-parens": false,
-    "eofline": false,
-    "import-spacing": false,
-    "indent": false,
-    "linebreak-style": false,
-    "max-line-length": false,
-    "new-parens": false,
-    "no-consecutive-blank-lines": false,
-    "no-irregular-whitespace": false,
-    "no-trailing-whitespace": false,
-    "object-literal-key-quotes": false,
-    "one-line": false,
-    "quotemark": false,
-    "semicolon": false,
-    "space-before-function-paren": false,
-    "trailing-comma": false,
-    "whitespace": false,
-
-    // tslint-react (https://github.com/palantir/tslint-react)
-    "jsx-alignment": false,
-    "jsx-curly-spacing": false,
-    "jsx-no-multiline-js": false,
-    "jsx-wrap-multiline": false,
-
-    // tslint-eslint-rules (https://github.com/buzinas/tslint-eslint-rules)
-    "block-spacing": false,
-    "brace-style": false,
-    "no-multi-spaces": false,
-    "object-curly-spacing": false,
-    "space-in-parens": false,
-    "ter-arrow-parens": false,
-    "ter-arrow-spacing": false,
-    "ter-indent": false,
-    "ter-max-len": false,
-    "ter-no-irregular-whitespace": false
-  }
-}
+  rules,
+  jsRules: rules,
+};


### PR DESCRIPTION
Export same rules under the jsRules key, so that projects with both js and ts files linted with
tslint will get the rules applied.