### PR TITLE
chore(travis): remove yarn and setup greenkeeper-lockfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,20 @@ branches:
     - master
     - /^greenkeeper/.*$/
 cache:
-  yarn: true
   directories:
     - node_modules
 notifications:
   email: false
 node_js:
   - node
+before_install:
+  - npm install -g greenkeeper-lockfile@1
+before_script:
+  - greenkeeper-lockfile-update
 script:
   - npm run lint
   - npm run test -- --ci --verbose --coverage
 after_success:
   - npm run semantic-release
+after_script:
+  - greenkeeper-lockfile-upload


### PR DESCRIPTION
- if we decided not to use yarn, then there's no need to set `yarn: true` on travis.
- [`greenkeeper-lockfile`](https://github.com/greenkeeperio/greenkeeper-lockfile) also supports `package-lock.json`.