### PR TITLE
feat(rules): add tslint/newline-per-chained-call

### DIFF
--- a/src/tslint/newline-per-chained-call/__snapshots__/test.ts.snap
+++ b/src/tslint/newline-per-chained-call/__snapshots__/test.ts.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should affect error message after formatting 1`] = `
+"
+<<<<<< before
+ERROR: (newline-per-chained-call) /src/tslint/newline-per-chained-call/test.ts[4, 6]: When chaining calls, put method calls on new lines.
+ERROR: (newline-per-chained-call) /src/tslint/newline-per-chained-call/test.ts[4, 12]: When chaining calls, put method calls on new lines.
+
+======
+ERROR: (newline-per-chained-call) /src/tslint/newline-per-chained-call/test.ts[1, 6]: When chaining calls, put method calls on new lines.
+
+>>>>>> after
+"
+`;
+
+exports[`should be pretty after formatting 1`] = `
+"
+<<<<<< before
+foo()
+  .bar()
+
+foo().bar().baz()
+
+======
+foo().bar();
+
+foo()
+  .bar()
+  .baz();
+
+>>>>>> after
+"
+`;

--- a/src/tslint/newline-per-chained-call/test.ts
+++ b/src/tslint/newline-per-chained-call/test.ts
@@ -1,0 +1,4 @@
+foo()
+  .bar()
+
+foo().bar().baz()

--- a/src/tslint/newline-per-chained-call/tslint.json
+++ b/src/tslint/newline-per-chained-call/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "newline-per-chained-call": true
+  }
+}

--- a/tools/__snapshots__/checker.test.ts.snap
+++ b/tools/__snapshots__/checker.test.ts.snap
@@ -14,6 +14,7 @@ indent
 linebreak-style
 max-line-length
 new-parens
+newline-per-chained-call
 no-consecutive-blank-lines
 no-irregular-whitespace
 no-trailing-whitespace


### PR DESCRIPTION
This rule was introduced in tslint 5.9.0, but I forgot to add it in #92. 😅