### PR TITLE
feat(rules): add tslint-eslint-rules/ter-padded-blocks

### DIFF
--- a/src/tslint-eslint-rules/ter-padded-blocks/__snapshots__/test.ts.snap
+++ b/src/tslint-eslint-rules/ter-padded-blocks/__snapshots__/test.ts.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should affect error message after formatting 1`] = `
+"
+<<<<<< before
+no error
+
+======
+ERROR: (ter-padded-blocks) /src/tslint-eslint-rules/ter-padded-blocks/test.ts[1, 11]: Block must be padded by blank lines.
+
+>>>>>> after
+"
+`;
+
+exports[`should be pretty after formatting 1`] = `
+"
+<<<<<< before
+if (true) {
+
+  somebody.doSomething();
+
+}
+
+======
+if (true) {
+  somebody.doSomething();
+}
+
+>>>>>> after
+"
+`;

--- a/src/tslint-eslint-rules/ter-padded-blocks/test.ts
+++ b/src/tslint-eslint-rules/ter-padded-blocks/test.ts
@@ -1,0 +1,5 @@
+if (true) {
+
+  somebody.doSomething();
+
+}

--- a/src/tslint-eslint-rules/ter-padded-blocks/tslint.json
+++ b/src/tslint-eslint-rules/ter-padded-blocks/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tslint.json",
+  "rules": {
+    "ter-padded-blocks": [true, "always"]
+  }
+}


### PR DESCRIPTION
This rule was introduced in [tslint-eslint-rules@5.1.0](https://github.com/buzinas/tslint-eslint-rules/blob/v5.1.0/CHANGELOG.md), see <https://eslint.org/docs/rules/padded-blocks>.