### PR TITLE
Allow tslint-config-prettier-check to run against multiple files

### DIFF
--- a/bin/check.js
+++ b/bin/check.js
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 
-try {
-  require("../lib/checker").check(process.argv[2]);
-} catch (e) {
-  if (e.name === "ConflictRules") {
-    console.log(e.message);
-    process.exitCode = 1;
-  } else {
-    throw e;
+process.argv.slice(2).forEach(file => {
+  try {
+    require("../lib/checker").check(file);
+  } catch (e) {
+    if (e.name === "ConflictRules") {
+      console.log(e.message);
+      process.exitCode = 1;
+    } else {
+      throw e;
+    }
   }
-}
+});


### PR DESCRIPTION
It's a very silly one-liner type of change, and therefore has limitations, but it does the job and lets you do things like:

```sh
tslint-config-prettier-check ./tslint.yml ./bin/tslint.yml ./test/tslint.yml
tslint-config-prettier-check .{,/**}/tslint.yml
```

In my local testing, both would output:

```
$ tslint-config-prettier-check .{,/**}/tslint.yml
No conflict rule detected in ./tslint.yml
No conflict rule detected in ./bin/tslint.yml
No conflict rule detected in ./test/tslint.yml
```

I went for a silly `forEach` instead of `node-glob`. I don't think it's worth the trouble, but let me know if you prefer otherwise.