### PR TITLE
chore(travis): preserve `npm install`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ node_js:
   - node
 before_install:
   - npm install -g greenkeeper-lockfile@1
+install:
+  - npm install
 before_script:
   - greenkeeper-lockfile-update
 script:


### PR DESCRIPTION
The default `install` script on Travis is now `npm ci` instead of `npm install`, which causes `package-lock.json` and `greenkeeper` to be incompatible, see the travis build in #149 for example.