### PR TITLE
Fix david badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![npm](https://img.shields.io/npm/v/tslint-config-prettier.svg)](https://www.npmjs.com/package/tslint-config-prettier)
 [![Travis](https://img.shields.io/travis/alexjoverm/tslint-config-prettier.svg)](https://travis-ci.org/alexjoverm/tslint-config-prettier)
 [![downloads](https://img.shields.io/npm/dm/tslint-config-prettier.svg)](https://www.npmjs.com/package/tslint-config-prettier)
-[![David](https://img.shields.io/david/alexjoverm/tslint-config-prettier.svg)]()
-[![David](https://img.shields.io/david/dev/alexjoverm/tslint-config-prettier.svg)]()
+[![dependencies Status](https://img.shields.io/david/alexjoverm/tslint-config-prettier.svg)](https://david-dm.org/alexjoverm/tslint-config-prettier)
+[![devDependencies Status](https://img.shields.io/david/dev/alexjoverm/tslint-config-prettier.svg)](https://david-dm.org/alexjoverm/tslint-config-prettier?type=dev)
 [![Greenkeeper badge](https://badges.greenkeeper.io/alexjoverm/tslint-config-prettier.svg)](https://greenkeeper.io/)
 
 <h3> :cop: tslint  +  :nail_care: prettier = :heart_eyes: </h3>


### PR DESCRIPTION
They should point to the deps list as is recommended on david-dm.org