### PR TITLE
chore(travis): remove greenkeeper-lockfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,10 @@ notifications:
   email: false
 node_js:
   - node
-before_install:
-  - npm install -g greenkeeper-lockfile@1
 install:
   - npm install
-before_script:
-  - greenkeeper-lockfile-update
 script:
   - npm run lint
   - npm run test -- --ci --verbose --coverage
 after_success:
   - npm run semantic-release
-after_script:
-  - greenkeeper-lockfile-upload


### PR DESCRIPTION
Greenkeeper now supports [updating lockfile natively](https://blog.greenkeeper.io/announcing-native-lockfile-support-85381a37a0d0), see #186 for example.